### PR TITLE
fix publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*
+
 !/.gitignore
 !/.gitmodules
 !/.jest.config.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+src

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/proto-tx-builder",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Builds and signs new-style protobuf SIGN_MODE_DIRECT Cosmos SDK transactions",
   "author": "ShapeShift DAO",
   "license": "MIT",


### PR DESCRIPTION
Without a npmignore npm defaults to a gitignore, and then fails to publish a dist directory. This pr adds a npmignore and fix's publishing. 